### PR TITLE
Update intel_core_i5_2410m.rst

### DIFF
--- a/source/studio/hardware/intel_core_i5_2410m.rst
+++ b/source/studio/hardware/intel_core_i5_2410m.rst
@@ -4,7 +4,7 @@
 Intel Core i5-2410M处理器
 ============================
 
-在我的模拟云计算环境中，主要使用 :ref:`intel_core_i7_4850hq` 的 :ref:`ubuntu_on_mbp` 来模拟大规模的云计算环境。同时，采用 :ref:`ubuntu_on_thinkpad_x220` 作为辅助环境，运行 Docker 和 Kuybernetes 分担一部分计算负载。
+在我的模拟云计算环境中，主要使用 :ref:`intel_core_i7_4850hq` 的 :ref:`ubuntu_on_mbp` 来模拟大规模的云计算环境。同时，采用 :ref:`ubuntu_on_thinkpad_x220` 作为辅助环境，运行 Docker 和 Kubernetes 分担一部分计算负载。
 
 ThinkPad X220的处理器是 `Intel® Core™ i5-2410M Processor <https://ark.intel.com/content/www/us/en/ark/products/52224/intel-core-i5-2410m-processor-3m-cache-up-to-2-90-ghz.html>`_ ，主要特性有:
 


### PR DESCRIPTION
## What does this PR do?  
- Corrects the misspelled term "Kuybernetes" to the correct "kubernetes".  
- This is a pure typo fix 

## Why is this needed?  
The correct spelling is "kubernetes" (all lowercase):  
- Official project name: https://kubernetes.io/  
- Confirmed via [CNCF branding guidelines](https://www.cncf.io/brand-guidelines/)  

## Files changed  
- `cloud-atlas/source/studio/hardware/intel_core_i5_2410m.rst` (line 7)  

## Verification  
Ensured no remaining misspellings exist:  
```sh
git grep -i "Kuybernetes" -- '*.md' '*.txt'